### PR TITLE
fix: Zola 0.22 [markdown.highlighting] config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -58,9 +58,9 @@ privacy = "Privacy"
 terms = "Termini"
 language = "Lingua"
 
-[markdown]
-highlight_code = true
-highlight_theme = "ayu-dark"
+[markdown.highlighting]
+enabled = true
+theme = "ayu-dark"
 
 [extra]
 site_name = "resysto"


### PR DESCRIPTION
The migration build failed because the GitHub Actions runner uses a newer Zola (0.22.1) than the old shalzz action did. Zola moved syntax-highlight config from `[markdown]` (`highlight_code`/`highlight_theme`) into `[markdown.highlighting]` (`enabled`/`theme`). Verified locally with a full `zola build` (sitemap + feeds render with resysto.ai).